### PR TITLE
Update LinqPad reference to a NuGet package

### DIFF
--- a/DB2DataContextDriver/DB2DataContextDriver.csproj
+++ b/DB2DataContextDriver/DB2DataContextDriver.csproj
@@ -47,9 +47,9 @@
       <HintPath>..\packages\linq2db.1.7.5\lib\net45\linq2db.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="LINQPad">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\LINQPad5\LINQPad.exe</HintPath>
-      <Private>False</Private>
+    <Reference Include="LINQPad, Version=1.0.0.0, Culture=neutral, PublicKeyToken=21353812cd2a2db5, processorArchitecture=MSIL">
+      <HintPath>..\packages\LINQPad.4.51.3\lib\net40\LINQPad.exe</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/DB2DataContextDriver/packages.config
+++ b/DB2DataContextDriver/packages.config
@@ -4,4 +4,5 @@
   <package id="linq2db" version="1.7.5" targetFramework="net452" />
   <package id="linq2db.DB2" version="1.0.7.5" targetFramework="net452" />
   <package id="linq2db.t4models" version="1.0.7.5" targetFramework="net452" />
+  <package id="LINQPad" version="4.51.3" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Linking to the LinqPad executable in the old way causes build issues when the workspace isn't set up a certain way. The NuGet package makes it easier for new developers to just clone and start working.